### PR TITLE
Fix KeyError in SecondSpectrum data loading

### DIFF
--- a/kloppy/infra/serializers/tracking/secondspectrum.py
+++ b/kloppy/infra/serializers/tracking/secondspectrum.py
@@ -71,7 +71,12 @@ class SecondSpectrumDeserializer(
             ball_coordinates = None
             ball_speed = None
 
-        ball_state = BallState.ALIVE if frame_data["eventType"] != "stoppage" else BallState.DEAD
+        event_type = frame_data.get("eventType")
+        if event_type is None:
+            event_type = None
+            logger.warning("Missing 'eventType' key in frame_data")
+
+        ball_state = BallState.ALIVE if event_type != "stoppage" else BallState.DEAD
         ball_owning_team = (
             teams[0] if frame_data["lastTouch"] == "home" else teams[1]
         )

--- a/kloppy/tests/test_secondspectrum.py
+++ b/kloppy/tests/test_secondspectrum.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import logging
 
 import pytest
 
@@ -455,3 +456,20 @@ class TestSecondSpectrumTracking:
         assert dataset.records[0].created_utc == 1234567890
         assert dataset.records[0].updated_utc == 1234567890
         assert dataset.records[0].deleted_utc == None
+
+    def test_missing_event_type_handling(
+        self, meta_data: Path, raw_data: Path, additional_meta_data: Path, caplog
+    ):
+        with caplog.at_level(logging.WARNING):
+            dataset = secondspectrum.load(
+                meta_data=meta_data,
+                raw_data=raw_data,
+                additional_meta_data=additional_meta_data,
+                only_alive=False,
+                coordinates="secondspectrum",
+            )
+
+            assert "Missing 'eventType' key in frame_data" in caplog.text
+
+            # Check that the default value of None is used for eventType
+            assert dataset.records[0].event_type is None


### PR DESCRIPTION
Handle missing 'eventType' key in SecondSpectrum data loading.

* Add a check for the existence of the `eventType` key in the `_frame_from_framedata` method in `kloppy/infra/serializers/tracking/secondspectrum.py`.
* Provide a default value of `None` for `eventType` if the key is missing.
* Log a warning message when the `eventType` key is missing to alert the user.
* Add a test case in `kloppy/tests/test_secondspectrum.py` to check the handling of missing `eventType` key.
* Verify that the default value of `None` is used for `eventType` when the key is missing.
* Verify that a warning message is logged when the `eventType` key is missing.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WoutPaepenUcLL/kloppy/pull/4?shareId=750d1c19-ff5d-4124-8983-2113de45152c).